### PR TITLE
Sort table entries by version number before displaying

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -502,20 +502,33 @@
                 .catch(error => console.error('Error fetching inspect data', ver, extra, error));
         }
 
+        
+        // Normalizes a MikroTik version string for easy sorting. Uses a SemVer-style (MAJOR.MINOR.PATCH-BUILD) format
+        // with MAJOR/MINOR/PATCH zero-padded to 2-digits, and BUILD defaulting to 'release' (so '5.0rc1' ends up sorted before '5.0').
+        // e.g.  6.49.13beta2  →  06.49.13-beta2
+        //       7.9           →  07.09.00-release
+        const normalizeVersion = (versionStr) => versionStr.replace(
+            /^(\d+)\.(\d+)(?:\.(\d+))?([^\d\s].+)?$/,
+            (_, major, minor, patch = '', build = 'release') => `${major.padStart(2, 0)}.${minor.padStart(2, 0)}.${patch.padStart(2, 0)}-${build}`
+        );
 
         // "MAIN" - fetch all the version from GitHub, which triggers everything via builddir
         fetch(`https://api.github.com/repos/${owner}/${repo}/contents/${path}`)
             .then(response => response.json())
             .then(data => {
-                data.forEach(file => {
-                    if (file.type === "dir") {
-                        console.debug("Got file from GitHub", file)
-                        file.pagesUrl = `${pagesUrl}/${file.path.replace('docs/', '')}`
-                        if (file.name !== "extra") {
-                            document.dispatchEvent(new CustomEvent("builddir", { detail: file }))
-                        }
-                    }
-                })
+                const versionDirs = data.filter(file => file.type === "dir" && file.name !== 'extra');
+                
+                const sortedDirs = versionDirs.toSorted((dirA, dirB) => {
+                    const versionA = normalizeVersion(dirA.name);
+                    const versionB = normalizeVersion(dirB.name);
+                    return (versionA === versionB) ? 0 : (versionA > versionB) ? 1 : -1;
+                });
+
+                for (const dir of sortedDirs) {
+                    console.debug("Got dir from GitHub", dir)
+                    dir.pagesUrl = `${pagesUrl}/${dir.path.replace('docs/', '')}`
+                    document.dispatchEvent(new CustomEvent("builddir", { detail: dir }))
+                }
             })
             .catch(error => console.error('Error fetching build list from GitHub:', error));
 


### PR DESCRIPTION
This adds functionality to sort the directory/version list received from GitHub before displaying them in the table, so `7.9.2` doesn't come after `7.18` anymore.

### Details
It's primarily just calling `.toSorted()` on the file array before displaying. However, since MikroTik version strings don't string-sort well (because of their variable number of version components), I added a small `normalizeVersion` function, which formats a MikroTik version string into a SemVer-style version format, padded to 2-digits and a default 'build' value (`XX.YY.ZZ-BUILD`), for easier sorting.

The normalized version isn't visible anywhere, but any string not matching the expected input format would just stay as-is.

### Known Limitations
- Since it's "only" 2 digits, something like `7.104` would sort incorrectly.
- Not sure if there are any other build types besides `beta` and `rc`, but something like `6.50lts` would also potentially sort incorrectly (before `6.50.rc1`).